### PR TITLE
Feat/fix publish ci

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,10 +1,6 @@
 name: Publish Package to npmjs
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "The branch to build"
-        required: true
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
This will fix the yarn command in release github Action, the orginal `yarn npm publish` is for yarn 2 version.